### PR TITLE
chore: adds context property in Setting annotation

### DIFF
--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
@@ -34,6 +34,11 @@ public @interface Setting {
      */
     String value() default "";
 
+    /**
+     * The setting context
+     */
+    String context() default "";
+
     String type() default "string";
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a `context` property in the `Setting` annotation. It's already possible today to set a context to a group of `Setting`s  with the `SettingContext` annotation in the extension class, but that will affect all the `Setting` in that extension.  

## Why it does that

documentation

