### PR TITLE
feat: add deprecated field to ConfigurationSetting

### DIFF
--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/domain/ConfigurationSetting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/domain/ConfigurationSetting.java
@@ -37,6 +37,7 @@ public class ConfigurationSetting {
     private Long maximum;
     private String description;
     private String defaultValue;
+    private boolean deprecated = false;
 
     private ConfigurationSetting() {
     }
@@ -90,8 +91,18 @@ public class ConfigurationSetting {
         return description;
     }
 
+    /**
+     * Returns the default value.
+     */
     public String getDefaultValue() {
         return defaultValue;
+    }
+
+    /**
+     * Returns true if the setting is deprecated, false otherwise.
+     */
+    public boolean isDeprecated() {
+        return deprecated;
     }
 
     @Override
@@ -161,6 +172,11 @@ public class ConfigurationSetting {
 
         public Builder defaultValue(String defaultValue) {
             setting.defaultValue = defaultValue;
+            return this;
+        }
+
+        public Builder deprecated(boolean deprecated) {
+            setting.deprecated = deprecated;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds `deprecated` field to `ConfigurationSettings`

## Why it does that

https://github.com/eclipse-edc/GradlePlugins/issues/251

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
