### PR TITLE
refactor: deprecate Base and Core extension annotations

### DIFF
--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/BaseExtension.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/BaseExtension.java
@@ -22,9 +22,12 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that an extension belongs to the runtime core and should always be loaded first.
+ *
+ * @deprecated this annotation is not used anymore and can be removed
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
+@Deprecated(since = "0.11.0")
 public @interface BaseExtension {
 }

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/CoreExtension.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/CoreExtension.java
@@ -23,10 +23,13 @@ import java.lang.annotation.Target;
 /**
  * Indicates that an extension pertains to the core:transfer module, which will cause it to receive special treatment
  * upon extension loading.
+ *
+ * @deprecated this annotation is not used anymore and can be removed
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
+@Deprecated(since = "0.11.0")
 public @interface CoreExtension {
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Deprecated `@BaseExtension` and `@CoreExtension` annotations.

## Why it does that

they're not used anymore (see https://github.com/eclipse-edc/Connector/pull/4593)

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
