### PR TITLE
feat: add config injection annotations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 jackson = "2.18.1"
-edc-build = "0.11.0-SNAPSHOT"
+edc-build = "0.10.1"
 jetbrainsAnnotation = "26.0.1"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 jackson = "2.18.1"
-edc-build = "0.10.1"
+edc-build = "0.11.0-SNAPSHOT"
 jetbrainsAnnotation = "26.0.1"
 
 [libraries]

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Configuration.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Configuration.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation indicates that a certain field is a "configuration object", i.e. a POJO that contains fields annotated with
+ * Indicates that a certain field is a "configuration object", i.e. a POJO that contains fields annotated with
  * {@link Setting}. These fields must be declared inside an extension class. Their respective class declaration must be annotated
  * with {@link Settings}.
  * Types annotated with this annotation will get instantiated by the EDC dependency injection mechanism using values from the config.

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Configuration.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Configuration.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.runtime.metamodel.annotation;
 
 import java.lang.annotation.Documented;

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Configuration.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Configuration.java
@@ -1,0 +1,19 @@
+package org.eclipse.edc.runtime.metamodel.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation indicates that a certain field is a "configuration object", i.e. a POJO that contains fields annotated with
+ * {@link Setting}. These fields must be declared inside an extension class. Their respective class declaration must be annotated
+ * with {@link Settings}.
+ * Types annotated with this annotation will get instantiated by the EDC dependency injection mechanism using values from the config.
+ */
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Configuration {
+}

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
@@ -34,8 +34,7 @@ public @interface Setting {
     /**
      * The setting description.
      *
-     * @deprecated Please use {@link Setting#description()} to supply description. In future releases this property will hold the
-     * Setting's config key!
+     * @deprecated Please use {@link Setting#description()} to supply description. In future releases this property will hold the Setting's config key!
      */
     @Deprecated
     String value() default NULL;
@@ -46,6 +45,8 @@ public @interface Setting {
     String context() default NULL;
 
     /**
+     * Type of the config value
+     *
      * @deprecated this attribute is deprecated because it will be inferred from the field
      */
     @Deprecated

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Setting.java
@@ -22,23 +22,33 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Denotes a runtime configuration setting.
+ * Denotes a runtime configuration setting. This can be put on config value fields and the dependency injection mechanism will
+ * attempt to automatically resolve them.
  */
-@Target({ ElementType.TYPE, ElementType.FIELD })
+@Target({ ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Setting {
+    String NULL = "";
 
     /**
      * The setting description.
+     *
+     * @deprecated Please use {@link Setting#description()} to supply description. In future releases this property will hold the
+     * Setting's config key!
      */
-    String value() default "";
+    @Deprecated
+    String value() default NULL;
 
     /**
      * The setting context
      */
-    String context() default "";
+    String context() default NULL;
 
+    /**
+     * @deprecated this attribute is deprecated because it will be inferred from the field
+     */
+    @Deprecated
     String type() default "string";
 
     /**
@@ -46,7 +56,7 @@ public @interface Setting {
      *
      * @return the setting's default value
      */
-    String defaultValue() default "";
+    String defaultValue() default NULL;
 
     long min() default Long.MIN_VALUE;
 
@@ -55,6 +65,26 @@ public @interface Setting {
     /**
      * Returns true if the setting is required.
      */
-    boolean required() default false;
+    boolean required() default true;
 
+    /**
+     * The key of the property, e.g. "edc.foo.bar.baz". If this attribute is present, the dependency injection mechanism
+     * will attempt to resolve the config value.
+     */
+    String key() default NULL;
+
+    /**
+     * The Setting's description. This is equivalent to {@link Setting#value()} in the current release, but users should
+     * use this attribute.
+     *
+     * @return The setting's description.
+     */
+    String description() default NULL;
+
+    /**
+     * Specify whether a warning should be issued when an optional config value is missing or when the default value is used.
+     * If set to false, a debug log is issued.
+     * Note that this is ignored on mandatory (non-optional) config values.
+     */
+    boolean warnOnMissingConfig() default false;
 }

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Settings.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Settings.java
@@ -1,0 +1,17 @@
+package org.eclipse.edc.runtime.metamodel.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that a certain class is a "configuration object", i.e. contains fields annotated with {@link Setting}. Note that
+ * if the configuration object is a record, it may ONLY contain fields annotated with {@link Setting}.
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.CLASS)
+@Documented
+public @interface Settings {
+}

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Settings.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Settings.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.runtime.metamodel.annotation;
 
 import java.lang.annotation.Documented;


### PR DESCRIPTION
## What this PR changes/adds

This pr introduces two new annotations that are needed for configuration injection, and it updates the `@Setting` annotation.

## Why it does that

preparatory work for https://github.com/eclipse-edc/Connector/issues/4610

## Further notes

- I did think about re-using `@Setting` in lieu of `@Configuration`, but that would have made code paths in the `autodoc` processor more complicated and hard to understand  

## Linked Issue(s)

Contributes to https://github.com/eclipse-edc/Connector/issues/4610

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
