### PR TITLE
feat: add context to configuration annotation, deprecate SettingContext

### DIFF
--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Configuration.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/Configuration.java
@@ -30,4 +30,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Configuration {
+
+    /**
+     * The configuration context
+     */
+    String context() default "";
 }

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/SettingContext.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/annotation/SettingContext.java
@@ -22,10 +22,13 @@ import java.lang.annotation.Target;
 
 /**
  * Defines a context for setting keys.
+ *
+ * @deprecated use {@link Configuration} or {@link Setting} context instead
  */
 @Target({ ElementType.TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Deprecated(since = "0.18.0")
 public @interface SettingContext {
     String value();
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds `context` attribute to `@Configuration`, that's meant to replace the `@SettingContext` annotation.

## Why it does that

simplicity

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #124 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
