### PR TITLE
build: bump jackson to 3.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ format.version = "1.1"
 [versions]
 # the edc-boot-spi dependency is used only for tests, this fixed version prevents the "chicken-egg" problem
 edc-test = "0.18.0"
-jackson = "2.22.1"
+jackson = "3.2.1"
 jackson-annotations = "2.22"
 jetbrainsAnnotation = "26.1.0"
 
@@ -12,8 +12,8 @@ jetbrainsAnnotation = "26.1.0"
 edc-boot-spi = { module = "org.eclipse.edc:boot-spi", version.ref = "edc-test" }
 j2html = { module = "com.j2html:j2html", version = "1.6.0" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson-annotations" }
-jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-core = { module = "tools.jackson.core:jackson-core", version.ref = "jackson" }
+jackson-databind = { module = "tools.jackson.core:jackson-databind", version.ref = "jackson" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotation" }
 markdown-gen = { module = "net.steppschuh.markdowngenerator:markdowngenerator", version = "1.3.1.1" }
 

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReader.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReader.java
@@ -14,14 +14,14 @@
 
 package org.eclipse.edc.plugins.autodoc.json;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.plugins.autodoc.spi.ManifestConverterException;
 import org.eclipse.edc.plugins.autodoc.spi.ManifestReader;
 import org.eclipse.edc.runtime.metamodel.domain.EdcModule;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.BufferedInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
@@ -39,7 +39,7 @@ public class JsonManifestReader implements ManifestReader {
     public List<EdcModule> read(InputStream inputStream) {
         try {
             return objectMapper.readValue(new InputStreamReader(new BufferedInputStream(inputStream)), MODULE_TYPE_REF);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new ManifestConverterException(e);
         }
     }

--- a/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReaderTest.java
+++ b/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReaderTest.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.edc.plugins.autodoc.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.plugins.autodoc.spi.ManifestConverterException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.InputStream;
 
@@ -46,7 +46,7 @@ class JsonManifestReaderTest {
     void read_inputNotJson() {
         assertThatThrownBy(() -> reader.read(readResource("invalid_manifest.json")))
                 .isInstanceOf(ManifestConverterException.class)
-                .hasRootCauseInstanceOf(JsonProcessingException.class);
+                .hasRootCauseInstanceOf(JacksonException.class);
     }
 
     private InputStream readResource(String filename) {

--- a/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
+++ b/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.edc.plugins.autodoc.markdown;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.plugins.autodoc.spi.ManifestWriter;
 import org.eclipse.edc.runtime.metamodel.domain.ConfigurationSetting;
 import org.eclipse.edc.runtime.metamodel.domain.EdcModule;
@@ -23,6 +21,8 @@ import org.eclipse.edc.runtime.metamodel.domain.EdcServiceExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/JsonFileAppender.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/JsonFileAppender.java
@@ -14,15 +14,15 @@
 
 package org.eclipse.edc.plugins.autodoc.tasks;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -63,32 +63,20 @@ class JsonFileAppender {
 
         LOCK.lock();
         try {
-            var srcContent = readJsonFile(source);
-            var targetContent = readJsonFile(destination);
+            var srcContent = mapper.readValue(source, listTypeReference);
+            var targetContent = mapper.readValue(source, listTypeReference);
 
             var newContent = new ArrayList<>();
             newContent.addAll(targetContent);
             newContent.addAll(srcContent);
 
-            writeJsonFile(newContent, destination);
-        } catch (IOException e) {
+            mapper.writeValue(destination, newContent);
+        } catch (JacksonException e) {
             throw new GradleException("Error reading input manifest", e);
         } finally {
             LOCK.unlock();
         }
 
-    }
-
-    private void writeJsonFile(List<?> content, File destination) throws IOException {
-        mapper.writeValue(destination, content);
-    }
-
-    private List<?> readJsonFile(File source) throws IOException {
-        try {
-            return mapper.readValue(source, listTypeReference);
-        } catch (IOException ex) {
-            return Collections.emptyList();
-        }
     }
 
     private void checkOrCreate(File destination) {

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MarkdownRendererTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MarkdownRendererTask.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.plugins.autodoc.tasks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.plugins.autodoc.html.HtmlManifestRenderer;
 import org.eclipse.edc.plugins.autodoc.json.JsonManifestReader;
 import org.eclipse.edc.plugins.autodoc.markdown.MarkdownManifestRenderer;
@@ -24,6 +23,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.TaskAction;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessor.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessor.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.plugins.autodoc.core.processor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.plugins.autodoc.core.processor.introspection.ExtensionIntrospector;
 import org.eclipse.edc.plugins.autodoc.core.processor.introspection.ModuleIntrospector;
 import org.eclipse.edc.plugins.autodoc.core.processor.introspection.OverviewIntrospector;
@@ -23,6 +22,7 @@ import org.eclipse.edc.runtime.metamodel.domain.EdcModule;
 import org.eclipse.edc.runtime.metamodel.domain.EdcServiceExtension;
 import org.eclipse.edc.runtime.metamodel.domain.ModuleType;
 import org.jetbrains.annotations.Nullable;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessorTest.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessorTest.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.edc.plugins.autodoc.core.processor;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.plugins.autodoc.core.processor.testconfig.ServiceExtensionWithConfig;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.NotAnExtension;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.OptionalService;
@@ -41,6 +39,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.File;
 import java.io.IOException;

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/domain/ConfigurationSetting.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/domain/ConfigurationSetting.java
@@ -16,8 +16,8 @@ package org.eclipse.edc.runtime.metamodel.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.Objects;
 

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/domain/EdcModule.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/domain/EdcModule.java
@@ -15,8 +15,8 @@
 package org.eclipse.edc.runtime.metamodel.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/domain/EdcServiceExtension.java
+++ b/runtime-metamodel/src/main/java/org/eclipse/edc/runtime/metamodel/domain/EdcServiceExtension.java
@@ -15,8 +15,8 @@
 package org.eclipse.edc.runtime.metamodel.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/runtime-metamodel/src/test/java/org/eclipse/edc/runtime/metamodel/domain/ConfigurationSettingTest.java
+++ b/runtime-metamodel/src/test/java/org/eclipse/edc/runtime/metamodel/domain/ConfigurationSettingTest.java
@@ -14,16 +14,16 @@
 
 package org.eclipse.edc.runtime.metamodel.domain;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ConfigurationSettingTest {
 
     @Test
-    void verifySerializeDeserialize() throws JsonProcessingException {
+    void verifySerializeDeserialize() throws JacksonException {
         var mapper = new ObjectMapper();
         var configuration = ConfigurationSetting.Builder.newInstance()
                 .key("key1")

--- a/runtime-metamodel/src/test/java/org/eclipse/edc/runtime/metamodel/domain/EdcModuleTest.java
+++ b/runtime-metamodel/src/test/java/org/eclipse/edc/runtime/metamodel/domain/EdcModuleTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.runtime.metamodel.domain;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EdcModuleTest {
 
     @Test
-    void verifySerializeDeserialize() throws JsonProcessingException {
+    void verifySerializeDeserialize() throws JacksonException {
         var mapper = new ObjectMapper();
         var module = EdcModule.Builder.newInstance()
                 .modulePath("foo:bar")

--- a/runtime-metamodel/src/test/java/org/eclipse/edc/runtime/metamodel/domain/ServiceReferenceTest.java
+++ b/runtime-metamodel/src/test/java/org/eclipse/edc/runtime/metamodel/domain/ServiceReferenceTest.java
@@ -14,16 +14,16 @@
 
 package org.eclipse.edc.runtime.metamodel.domain;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ServiceReferenceTest {
 
     @Test
-    void verifySerializeDeserialize() throws JsonProcessingException {
+    void verifySerializeDeserialize() throws JacksonException {
         var mapper = new ObjectMapper();
         var service = new ServiceReference("foo.bar.BarService", false);
 

--- a/runtime-metamodel/src/test/java/org/eclipse/edc/runtime/metamodel/domain/ServiceTest.java
+++ b/runtime-metamodel/src/test/java/org/eclipse/edc/runtime/metamodel/domain/ServiceTest.java
@@ -14,16 +14,16 @@
 
 package org.eclipse.edc.runtime.metamodel.domain;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ServiceTest {
 
     @Test
-    void verifySerializeDeserialize() throws JsonProcessingException {
+    void verifySerializeDeserialize() throws JacksonException {
         var mapper = new ObjectMapper();
         var service = new Service("foo.bar.BarService");
 


### PR DESCRIPTION
## What this PR changes/adds

Bumps jackson dependencies to 3.2.1, including groupId and package name changes.
NOTE: jackson-annotations version stays at 2.22 ([ref.](https://github.com/FasterXML/jackson-annotations#release-notes))

This change doesn't break Connector nor IdentityHub, because in this repo they are only used for `autodoc` and not in runtime classes.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
